### PR TITLE
Fix eslint doesn't work in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
-  "eslint.validate": ["svelte"],
+  "eslint.validate": ["javascript", "typescript", "svelte"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded editor linting configuration to validate JavaScript, TypeScript, and Svelte files (previously Svelte only).
  * Improves consistency of code quality checks across more file types during development.
  * Developers may notice additional lint feedback in JS/TS files within the IDE.
  * No impact on application behavior or UI; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->